### PR TITLE
Quick fixes for some copy errors in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ struct UserSettings settings = {
 };
 ```
 
-But it also creates the initialization (`UserSettings_initialize`), serialization (`UserSettings_pack`), and deserialization (`UserSettings_initialize`) functions needed for the struct.
+But it also creates the initialization (`UserSettings_init`), serialization (`UserSettings_pack`), and deserialization (`UserSettings_unpack`) functions needed for the struct.
 
 ## C implementation
 


### PR DESCRIPTION
Just reading up on it and noticed these were wrong and/or didn't match the examples below. Good stuff!